### PR TITLE
Main: Catch and Log Fatal Exceptions to Console

### DIFF
--- a/CyborgianStates/Program.cs
+++ b/CyborgianStates/Program.cs
@@ -9,6 +9,7 @@ using System.IO;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using CyborgianStates.CommandHandling;
 using CyborgianStates.Services;
+using System.Threading.Tasks;
 
 namespace CyborgianStates
 {
@@ -17,14 +18,23 @@ namespace CyborgianStates
         static ILauncher Launcher = new Launcher();
         static IUserInput userInput = new ConsoleInput();
         static IMessageHandler messageHandler = new ConsoleMessageHandler(userInput);
-        
+
         public static IServiceProvider ServiceProvider { get; set; }
-        public static void Main()
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Required to be able to log fatal exceptions causing the bot to crash.")]
+        public static async Task Main()
         {
-            var serviceCollection = new ServiceCollection();
-            ConfigureServices(serviceCollection);
-            ServiceProvider = serviceCollection.BuildServiceProvider();
-            Launcher.RunAsync();
+            try
+            {
+                var serviceCollection = new ServiceCollection();
+                ConfigureServices(serviceCollection);
+                ServiceProvider = serviceCollection.BuildServiceProvider();
+                await Launcher.RunAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"A fatal error caused the bot to crash: {ex}");
+            }
         }
         public static void SetLauncher(ILauncher launcher)
         {


### PR DESCRIPTION
## Description
When starting the bot with the default config it just failed silently. Now the main method catches such fatal exceptions and write them to the Standard Error Output Stream.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The main method called `Launcher.RunAsync()` in a sync way. That caused the call to silently fail if a exception occured. Resulting in a crash of the bot.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: #50

This can be further improved by using actual logging and config checking for more concise error mesages before calling `Launcher.RunAsync()`

## How Has This Been Tested?
Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.

- [ ] My change requires a change to the documentation.

- [ ] I have updated the documentation accordingly.

- [ ] I have added tests to cover my changes.

- [x] All new and existing tests passed.

- [x] I have read the **CONTRIBUTING** document.
